### PR TITLE
Fix Kylin link

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,7 +118,7 @@
 <li><a href="https://github.com/m3db/m3">M3</a>,</li>
 <li><a href="https://github.com/NetApp/trident">trident</a>,</li>
 <li>Circonus&rsquo; <a href="https://www.circonus.com/2017/01/introducing-irondb/">IRONdb time-series database</a>,</li>
-<li>Apache Kylin](<a href="http://kylin.io">http://kylin.io</a>).</li>
+<li><a href="http://kylin.io">Apache Kylin</a>.</li>
 </ul>
 </p>
 		</div>


### PR DESCRIPTION
It seems like markdown syntax and html were mixed improperly, this looks like the following currently:

![image](https://github.com/RoaringBitmap/RoaringBitmapWebsite/assets/14916819/e8c4530d-9980-4f89-8c9a-2a4747262f7d)
